### PR TITLE
twister: Use proper warnings-to-errors command for sysbuild

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -329,11 +329,15 @@ class CMake:
             warnings_as_errors = 'n'
             gen_defines_args = ""
 
+        warning_command = 'CONFIG_COMPILER_WARNINGS_AS_ERRORS'
+        if self.testsuite.sysbuild:
+            warning_command = 'SB_' + warning_command
+
         logger.debug("Running cmake on %s for %s" % (self.source_dir, self.platform.name))
         cmake_args = [
             f'-B{self.build_dir}',
             f'-DTC_RUNID={self.instance.run_id}',
-            f'-DCONFIG_COMPILER_WARNINGS_AS_ERRORS={warnings_as_errors}',
+            f'-D{warning_command}={warnings_as_errors}',
             f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
             f'-G{self.env.generator}'
         ]


### PR DESCRIPTION
If sysbuild is used a flag SB_CONFIG_COMPILER_WARNINGS_AS_ERRORS has to be used in order to turn warings to errors on all images

Fixes: #67360